### PR TITLE
Fix precipitation values reading from entity attributes

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -49,6 +49,7 @@ class SimpleWeatherCard extends LitElement {
     if (entityObj && this.entity !== entityObj) {
       this.entity = entityObj;
       this.weather = new WeatherEntity(hass, entityObj);
+      this.updateForecast();
     }
     const newCustom = {};
     custom.forEach(ele => {
@@ -115,6 +116,29 @@ class SimpleWeatherCard extends LitElement {
 
     if (!this.config.secondary_info)
       this.config.secondary_info = [];
+  }
+
+  async updateForecast() {
+    if (!this.weather || !this._hass) return;
+
+    try {
+      // Try to fetch forecast using the new weather.get_forecasts service (HA 2023.9+)
+      const response = await this._hass.callService(
+        'weather',
+        'get_forecasts',
+        { type: 'daily' },
+        { entity_id: this.config.entity },
+        true // return response
+      );
+
+      if (response && response[this.config.entity]) {
+        this.weather.updateForecast(response[this.config.entity].forecast);
+        this.requestUpdate();
+      }
+    } catch (error) {
+      // Service not available or failed, forecast will fall back to entity attributes (legacy)
+      console.debug('Failed to fetch forecast via service, using legacy attribute method:', error);
+    }
   }
 
   shouldUpdate(changedProps) {

--- a/src/weather.js
+++ b/src/weather.js
@@ -73,7 +73,16 @@ export default class WeatherEntity {
     this.hass = hass;
     this.entity = entity;
     this.attr = entity.attributes;
-    this.forecast = entity.attributes.forecast || [[]];
+    // For backwards compatibility, check entity attributes first (pre-2024.4)
+    // If not available, initialize empty array (will be populated by updateForecast)
+    this.forecast = entity.attributes.forecast || [{}];
+  }
+
+  updateForecast(forecastData) {
+    // Update forecast data from weather.get_forecasts service (HA 2023.9+)
+    if (forecastData && forecastData.length > 0) {
+      this.forecast = forecastData;
+    }
   }
 
   get state() {
@@ -93,11 +102,11 @@ export default class WeatherEntity {
   }
 
   get high() {
-    return this.forecast[0].temperature;
+    return this.forecast[0] && this.forecast[0].temperature;
   }
 
   get low() {
-    return this.forecast[0].templow;
+    return this.forecast[0] && this.forecast[0].templow;
   }
 
   get wind_speed() {
@@ -115,11 +124,24 @@ export default class WeatherEntity {
   }
 
   get precipitation() {
-    return Math.round( (this.forecast[0].precipitation || 0) *100)/100;
+    // Check entity attributes first (some integrations may provide this)
+    // Then check forecast data (standard location for precipitation)
+    let value = 0;
+    if (this.attr.precipitation !== undefined && this.attr.precipitation !== null) {
+      value = this.attr.precipitation;
+    } else if (this.forecast[0] && this.forecast[0].precipitation !== undefined) {
+      value = this.forecast[0].precipitation;
+    }
+    return Math.round(value * 100) / 100;
   }
 
   get precipitation_probability() {
-    return this.forecast[0].precipitation_probability || 0;
+    // Check entity attributes first (some integrations may provide this)
+    // Then check forecast data (standard location for precipitation probability)
+    if (this.attr.precipitation_probability !== undefined && this.attr.precipitation_probability !== null) {
+      return this.attr.precipitation_probability;
+    }
+    return (this.forecast[0] && this.forecast[0].precipitation_probability) || 0;
   }
 
   get humidity() {


### PR DESCRIPTION
The precipitation and precipitation_probability getters were only reading from forecast data, causing them to always show 0 when the values were stored in the weather entity attributes (as is standard in Home Assistant).

This fix makes the card check entity attributes first (like other weather attributes such as wind_speed, pressure, humidity), then fall back to forecast data if not available.

Uses nullish coalescing (??) to properly handle 0 values.